### PR TITLE
feat: add user input handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ A simple game of guessing five letter words
 ## Project Requirements
 
 - [x] Emulated keyboard on mobile [^1]
-- [ ] Handle user input from physical keyboard
+- [x] Handle user input from physical keyboard
 
 [^1]: I'm not using a single input element, because that won't let me have letters in individual cells on the grid. And I'm not using multiple inputs either. This is bad in terms of user experience, since nobody would want to click on each cell and enter a letter. Though on desktop, I can handle user input using `"keypress"` event listeners

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ A simple game of guessing five letter words
 
 ## Project Requirements
 
-- [x] Display letters in mint green if they're in the word and at the right place
-- [x] Display letters in white if they're in the word, but placed somewhere else
-- [x] Display letters in gray if they're not in the word
-- [ ] Emulated keyboard on mobile [^1]
+- [x] Emulated keyboard on mobile [^1]
+- [ ] Handle user input from physical keyboard
 
 [^1]: I'm not using a single input element, because that won't let me have letters in individual cells on the grid. And I'm not using multiple inputs either. This is bad in terms of user experience, since nobody would want to click on each cell and enter a letter. Though on desktop, I can handle user input using `"keypress"` event listeners

--- a/src/GuessGrid.vue
+++ b/src/GuessGrid.vue
@@ -2,6 +2,7 @@
 import { ref } from "vue";
 
 import GuessRow from "./GuessRow.vue";
+import Keyboard from "./Keyboard.vue";
 
 /**
  * @typedef Props
@@ -34,13 +35,7 @@ const rows = ref(
 	}))
 );
 
-/**
-@param {Event} e
- */
-const handleChange = (e) => {
-	/** @type {HTMLInputElement} */
-	const input = e.currentTarget;
-	const value = input.value.toUpperCase();
+const handleSubmit = (value) => {
 	const cells = rows.value[pos.value].cells;
 
 	let hits = 0;
@@ -73,17 +68,7 @@ const handleChange = (e) => {
 		return { key, isInWord, isPosHit };
 	});
 
-	input.value = "";
-
 	rows.value[pos.value].isSubmitted = true;
-
-	if (pos.value === props.attempts - 1) {
-		model.value = true;
-
-		emit("fail");
-
-		return;
-	}
 
 	pos.value++;
 
@@ -91,7 +76,27 @@ const handleChange = (e) => {
 		model.value = true;
 
 		emit("pass", pos.value);
+
+		return;
 	}
+
+	if (pos.value === props.attempts) {
+		model.value = true;
+
+		emit("fail");
+	}
+};
+
+const handleRemove = (i) => {
+	const cells = rows.value[pos.value].cells;
+
+	cells[i].key = "";
+};
+
+const handleInsert = (i, key) => {
+	const cells = rows.value[pos.value].cells;
+
+	cells[i].key = key;
 };
 </script>
 
@@ -105,12 +110,10 @@ const handleChange = (e) => {
 		/>
 	</article>
 
-	<p>Note: Put your guess as a whole word in this field and press enter</p>
-	<div>
-		<input
-			type="text"
-			:maxlength="props.secret.length"
-			@change="handleChange"
-		/>
-	</div>
+	<Keyboard
+		:maxlength="props.secret.length"
+		@submit="handleSubmit"
+		@insert="handleInsert"
+		@remove="handleRemove"
+	/>
 </template>

--- a/src/GuessGrid.vue
+++ b/src/GuessGrid.vue
@@ -1,7 +1,8 @@
 <script setup>
-import { ref } from "vue";
+import { ref, onMounted, onUnmounted } from "vue";
 
 import useKeyboard from "./useKeyboard";
+import useOrientation from "./useOrientation";
 
 import GuessRow from "./GuessRow.vue";
 import Keyboard from "./Keyboard.vue";
@@ -25,6 +26,7 @@ const props = defineProps({
 const emit = defineEmits(["pass", "fail"]);
 
 const kb = useKeyboard(props.secret.length);
+const { isPortrait } = useOrientation();
 
 const pos = ref(0);
 
@@ -109,6 +111,41 @@ const handleEnter = () => {
 		emit("fail");
 	}
 };
+
+/**
+ * A function to handle user input on desktop
+ * @param {KeyboardEvent} e
+ */
+const handleKeyDown = (e) => {
+	console.log(e.key);
+
+	if (e.key === "Enter") {
+		handleEnter();
+
+		return;
+	}
+
+	if (e.key === "Backspace") {
+		handleDelete();
+
+		return;
+	}
+
+	// TODO: figure out how to get only letters
+	handleInput(e.key.toUpperCase());
+};
+
+onMounted(() => {
+	if (isPortrait.value) return;
+
+	document.addEventListener("keydown", handleKeyDown);
+});
+
+onUnmounted(() => {
+	if (isPortrait.value) return;
+
+	document.removeEventListener("keydown", handleKeyDown);
+});
 </script>
 
 <template>
@@ -121,11 +158,13 @@ const handleEnter = () => {
 		/>
 	</article>
 
-	<Keyboard
-		:isEnterDisabled="!kb.isEndOfLine.value"
-		:isDeleteDisabled="kb.isBufEmpty.value"
-		@input="handleInput"
-		@delete="handleDelete"
-		@enter="handleEnter"
-	/>
+	<template v-if="isPortrait">
+		<Keyboard
+			:isEnterDisabled="!kb.isEndOfLine.value"
+			:isDeleteDisabled="kb.isBufEmpty.value"
+			@input="handleInput"
+			@delete="handleDelete"
+			@enter="handleEnter"
+		/>
+	</template>
 </template>

--- a/src/Keyboard.vue
+++ b/src/Keyboard.vue
@@ -1,0 +1,179 @@
+<script setup>
+import { ref, computed } from "vue";
+
+/**
+ * @typedef Props
+ * @prop {number | undefined} maxlength
+ * @prop {(value: string) => void} onSubmit
+ * @prop {(pos: number, key: string) => void} onInsert
+ * @prop {(pos: number) => void} onRemove
+ */
+
+/**
+ * @typedef Cell
+ * @prop {string} key
+ * @prop {"submit" | "insert" | "remove"} action
+ */
+
+/** @type {Props} */
+const props = defineProps({ maxlength: Number });
+const emit = defineEmits(["submit", "insert", "remove"]);
+
+/** @type {import("vue").Ref<Cell[][]>> */
+const rows = ref([
+	[
+		{ key: "Q", action: "insert" },
+		{ key: "W", action: "insert" },
+		{ key: "E", action: "insert" },
+		{ key: "R", action: "insert" },
+		{ key: "T", action: "insert" },
+		{ key: "Y", action: "insert" },
+		{ key: "U", action: "insert" },
+		{ key: "I", action: "insert" },
+		{ key: "O", action: "insert" },
+		{ key: "P", action: "insert" },
+	],
+	[
+		{ key: "A", action: "insert" },
+		{ key: "S", action: "insert" },
+		{ key: "D", action: "insert" },
+		{ key: "F", action: "insert" },
+		{ key: "G", action: "insert" },
+		{ key: "H", action: "insert" },
+		{ key: "J", action: "insert" },
+		{ key: "K", action: "insert" },
+		{ key: "L", action: "insert" },
+	],
+	[
+		{ key: "Enter", action: "submit" },
+		{ key: "Z", action: "insert" },
+		{ key: "X", action: "insert" },
+		{ key: "C", action: "insert" },
+		{ key: "V", action: "insert" },
+		{ key: "B", action: "insert" },
+		{ key: "N", action: "insert" },
+		{ key: "M", action: "insert" },
+		{ key: "Delete", action: "remove" },
+	],
+]);
+
+const buf = ref("");
+const pos = ref(0);
+
+const isBufEmpty = computed(() => pos.value === 0);
+
+const isEndOfLine = computed(() => {
+	if (props.maxlength === undefined) return false;
+
+	return pos.value === props.maxlength;
+});
+
+const isSubmitDisabled = computed(() => {
+	if (isBufEmpty.value) return true;
+	if (props.maxlength === undefined) return false;
+
+	return !isEndOfLine.value;
+});
+
+/**
+ * @param {Cell} cell
+ */
+const getCellClass = (cell) => {
+	switch (cell.action) {
+		case "submit":
+			return `cell accent ${isSubmitDisabled.value ? "is-disabled" : ""}`;
+		case "remove":
+			return `cell ${isBufEmpty.value ? "is-disabled" : ""}`;
+		default:
+			return "cell";
+	}
+};
+
+/**
+ * @param {Cell} cell
+ */
+const handleCellClick = (cell) => {
+	if (cell.action === "remove" && isBufEmpty.value) return;
+
+	if (cell.action === "remove") {
+		pos.value--;
+		buf.value = buf.value.substring(0, pos.value);
+
+		emit("remove", pos.value);
+
+		return;
+	}
+
+	if (cell.action === "insert" && isEndOfLine.value) return;
+
+	if (cell.action === "insert") {
+		emit("insert", pos.value, cell.key);
+
+		buf.value += cell.key;
+		pos.value++;
+
+		return;
+	}
+
+	if (isSubmitDisabled.value) return;
+
+	emit("submit", buf.value);
+
+	buf.value = "";
+	pos.value = 0;
+};
+</script>
+
+<template>
+	<div class="container">
+		<div v-for="(row, i) in rows" :key="i" class="row">
+			<div
+				v-for="cell in row"
+				:key="cell.key"
+				:class="getCellClass(cell)"
+				@click="handleCellClick(cell)"
+			>
+				{{ cell.key }}
+			</div>
+		</div>
+	</div>
+</template>
+
+<style scoped>
+.container {
+	margin: 0.75rem 0;
+
+	display: grid;
+	justify-items: center;
+	row-gap: 0.375rem;
+}
+
+.row {
+	display: flex;
+	column-gap: 0.375rem;
+}
+
+.cell {
+	min-width: 1.5em;
+
+	padding: 0.375em 0.25em;
+
+	background-color: oklch(0.32 0 0);
+	border: 1px solid oklch(0.36 0 0);
+	border-radius: 0.125em;
+
+	text-align: center;
+	user-select: none;
+
+	box-sizing: border-box;
+}
+
+.cell.is-disabled {
+	color: oklch(1 0 0 / 0.25);
+}
+
+.cell.accent {
+	background-color: oklch(0.7 0.15 155);
+	border-color: oklch(0.74 0.15 155);
+}
+</style>

--- a/src/Keyboard.vue
+++ b/src/Keyboard.vue
@@ -2,125 +2,110 @@
 import { ref, computed } from "vue";
 
 /**
- * @typedef Props
- * @prop {number | undefined} maxlength
- * @prop {(value: string) => void} onSubmit
- * @prop {(pos: number, key: string) => void} onInsert
- * @prop {(pos: number) => void} onRemove
+ * @typedef Cell
+ * @prop {string} key
+ * @prop {"input" | "delete" | "enter"} action
  */
 
 /**
- * @typedef Cell
- * @prop {string} key
- * @prop {"submit" | "insert" | "remove"} action
+ * @typedef Props
+ * @prop {boolean} isEnterDisabled
+ * @prop {boolean} isDeleteDisabled
+ * @prop {(key: string) => void} onInput
+ * @prop {() => void} onDelete
+ * @prop {() => void} onEnter
  */
 
 /** @type {Props} */
-const props = defineProps({ maxlength: Number });
-const emit = defineEmits(["submit", "insert", "remove"]);
+const props = defineProps({
+	isEnterDisabled: { type: Boolean, required: true },
+	isDeleteDisabled: { type: Boolean, required: true },
+});
+
+const emit = defineEmits(["input", "delete", "enter"]);
 
 /** @type {import("vue").Ref<Cell[][]>> */
 const rows = ref([
 	[
-		{ key: "Q", action: "insert" },
-		{ key: "W", action: "insert" },
-		{ key: "E", action: "insert" },
-		{ key: "R", action: "insert" },
-		{ key: "T", action: "insert" },
-		{ key: "Y", action: "insert" },
-		{ key: "U", action: "insert" },
-		{ key: "I", action: "insert" },
-		{ key: "O", action: "insert" },
-		{ key: "P", action: "insert" },
+		{ key: "Q", action: "input" },
+		{ key: "W", action: "input" },
+		{ key: "E", action: "input" },
+		{ key: "R", action: "input" },
+		{ key: "T", action: "input" },
+		{ key: "Y", action: "input" },
+		{ key: "U", action: "input" },
+		{ key: "I", action: "input" },
+		{ key: "O", action: "input" },
+		{ key: "P", action: "input" },
 	],
 	[
-		{ key: "A", action: "insert" },
-		{ key: "S", action: "insert" },
-		{ key: "D", action: "insert" },
-		{ key: "F", action: "insert" },
-		{ key: "G", action: "insert" },
-		{ key: "H", action: "insert" },
-		{ key: "J", action: "insert" },
-		{ key: "K", action: "insert" },
-		{ key: "L", action: "insert" },
+		{ key: "A", action: "input" },
+		{ key: "S", action: "input" },
+		{ key: "D", action: "input" },
+		{ key: "F", action: "input" },
+		{ key: "G", action: "input" },
+		{ key: "H", action: "input" },
+		{ key: "J", action: "input" },
+		{ key: "K", action: "input" },
+		{ key: "L", action: "input" },
 	],
 	[
-		{ key: "Enter", action: "submit" },
-		{ key: "Z", action: "insert" },
-		{ key: "X", action: "insert" },
-		{ key: "C", action: "insert" },
-		{ key: "V", action: "insert" },
-		{ key: "B", action: "insert" },
-		{ key: "N", action: "insert" },
-		{ key: "M", action: "insert" },
-		{ key: "Delete", action: "remove" },
+		{ key: "Enter", action: "enter" },
+		{ key: "Z", action: "input" },
+		{ key: "X", action: "input" },
+		{ key: "C", action: "input" },
+		{ key: "V", action: "input" },
+		{ key: "B", action: "input" },
+		{ key: "N", action: "input" },
+		{ key: "M", action: "input" },
+		{ key: "Delete", action: "delete" },
 	],
 ]);
 
-const buf = ref("");
-const pos = ref(0);
+const enterKeyCls = computed(() => {
+	const cls = ["cell", "accent"];
 
-const isBufEmpty = computed(() => pos.value === 0);
+	if (props.isEnterDisabled) cls.push("is-disabled");
 
-const isEndOfLine = computed(() => {
-	if (props.maxlength === undefined) return false;
-
-	return pos.value === props.maxlength;
+	return cls.join(" ");
 });
 
-const isSubmitDisabled = computed(() => {
-	if (isBufEmpty.value) return true;
-	if (props.maxlength === undefined) return false;
+const deleteKeyCls = computed(() => {
+	const cls = ["cell"];
 
-	return !isEndOfLine.value;
+	if (props.isDeleteDisabled) cls.push("is-disabled");
+
+	return cls.join(" ");
 });
 
 /**
  * @param {Cell} cell
  */
-const getCellClass = (cell) => {
-	switch (cell.action) {
-		case "submit":
-			return `cell accent ${isSubmitDisabled.value ? "is-disabled" : ""}`;
-		case "remove":
-			return `cell ${isBufEmpty.value ? "is-disabled" : ""}`;
-		default:
-			return "cell";
-	}
+const getClassName = (cell) => {
+	if (cell.action === "input") return "cell";
+	if (cell.action === "delete") return deleteKeyCls.value;
+	if (cell.action === "enter") return enterKeyCls.value;
 };
 
 /**
  * @param {Cell} cell
  */
-const handleCellClick = (cell) => {
-	if (cell.action === "remove" && isBufEmpty.value) return;
-
-	if (cell.action === "remove") {
-		pos.value--;
-		buf.value = buf.value.substring(0, pos.value);
-
-		emit("remove", pos.value);
+const handleClick = (cell) => {
+	if (cell.action === "input") {
+		emit("input", cell.key);
 
 		return;
 	}
 
-	if (cell.action === "insert" && isEndOfLine.value) return;
-
-	if (cell.action === "insert") {
-		emit("insert", pos.value, cell.key);
-
-		buf.value += cell.key;
-		pos.value++;
+	if (cell.action === "delete") {
+		emit("delete");
 
 		return;
 	}
 
-	if (isSubmitDisabled.value) return;
+	if (props.isEnterDisabled) return;
 
-	emit("submit", buf.value);
-
-	buf.value = "";
-	pos.value = 0;
+	emit("enter");
 };
 </script>
 
@@ -130,8 +115,8 @@ const handleCellClick = (cell) => {
 			<div
 				v-for="cell in row"
 				:key="cell.key"
-				:class="getCellClass(cell)"
-				@click="handleCellClick(cell)"
+				:class="getClassName(cell)"
+				@click="handleClick(cell)"
 			>
 				{{ cell.key }}
 			</div>

--- a/src/useKeyboard.js
+++ b/src/useKeyboard.js
@@ -1,0 +1,55 @@
+import { ref, computed } from "vue";
+
+/**
+ * @param {number | undefined} size
+ */
+const useKeyboard = (size) => {
+	const buf = ref("");
+	const bufSize = ref(size || 1024);
+	const pos = ref(0);
+
+	const isBufEmpty = computed(() => pos.value === 0);
+	const isEndOfLine = computed(() => pos.value === bufSize.value);
+
+	/**
+	 * @param {string} char
+	 */
+	const put = (char) => {
+		const retval = pos.value;
+
+		if (isEndOfLine.value) return;
+
+		pos.value++;
+		buf.value += char;
+
+		return retval;
+	};
+
+	const remove = () => {
+		if (isBufEmpty.value) return;
+
+		pos.value--;
+		buf.value = buf.value.slice(0, pos.value);
+
+		return pos.value;
+	};
+
+	const flush = () => {
+		const retval = buf.value;
+
+		pos.value = 0;
+		buf.value = "";
+
+		return retval;
+	};
+
+	return {
+		isBufEmpty,
+		isEndOfLine,
+		put,
+		remove,
+		flush,
+	};
+};
+
+export default useKeyboard;

--- a/src/useOrientation.js
+++ b/src/useOrientation.js
@@ -1,0 +1,21 @@
+import { computed, ref } from "vue";
+
+const useOrientation = () => {
+	const orientation = computed(() => {
+		switch (screen.orientation.type) {
+			case "landscape-primary":
+			case "landscape-secondary":
+				return "landscape";
+			case "portrait-primary":
+			case "portrait-secondary":
+				return "portrait";
+		}
+	});
+
+	const isLandscape = computed(() => orientation.value === "landscape");
+	const isPortrait = computed(() => orientation.value === "portrait");
+
+	return { orientation, isLandscape, isPortrait };
+};
+
+export default useOrientation;


### PR DESCRIPTION
## Description

This PR add a composable to handle user input in general and the Keyboard component, that renders a virtual keyboard on mobile devices

## Changes Made

- Implemented the `useKeyboard` composable, that provides lower-level functions to handle user input
- Implemented the `useOrientation` composable, that helps detemine whether mobile or desktop device is used
- Added the Keyboard component. But right now it only uses the hardcoded QWERTY layout
- Modified the GuessGrid component to render virtual keyboard if the orientation is `"portrait"`, and register the `"keydown"` event listener otherwise to handle key presses from physical keyboard

## Things to Improve

- Having a hardcoded keyboard layout hardcoded is not ideal. Maybe have a composable for that?
- The `useOrientation` does not track when orientation changes. Initally I took inspiration from [vue-screen-orientation](https://github.com/medeiroz/vue-screen-orientation) and [screen-orientation-2](https://github.com/medeiroz/screen-orientation-2), but did not took into account detecting changes
- I don't like the way everything is implemented. Worth exploring, but too much to write here
